### PR TITLE
Eg 59 moves list arrow

### DIFF
--- a/pokemon-app/src/components/EnemyPokemon.js
+++ b/pokemon-app/src/components/EnemyPokemon.js
@@ -19,7 +19,7 @@ const EnemyPokemon = ({ enemyPokemon, hasEnemy }) => {
 
       setScrollTop(scrollTop);
 
-      scrollHeight - scrollTop === clientHeight
+      scrollHeight - scrollTop <= 1 + clientHeight
         ? setIsScrollBottom(true)
         : setIsScrollBottom(false);
     }

--- a/pokemon-app/src/components/EnemyPokemon.js
+++ b/pokemon-app/src/components/EnemyPokemon.js
@@ -1,29 +1,15 @@
-import React, { useState, useRef } from "react";
+import React, { useState } from "react";
 import fightPad from "../assets/fightpad.png";
 import "../styles/EnemyPokemon.css";
 import ThemeSongs from "./ThemeSongs";
 import fightSong from "../assets/fightSong.mp3";
 import Types from "./Types";
 import PokemonCry from "./PokemonCry";
+import { useScroll } from "../hooks";
 
 const EnemyPokemon = ({ enemyPokemon, hasEnemy }) => {
   const [enemyStatsOnTop, setEnemyStatsOnTop] = useState(true);
-  const [scrollTop, setScrollTop] = useState(0);
-  const [isScrollBottom, setIsScrollBottom] = useState(false);
-
-  const scrollRef = useRef();
-
-  const onScroll = () => {
-    if (scrollRef.current) {
-      const { clientHeight, scrollHeight, scrollTop } = scrollRef.current;
-
-      setScrollTop(scrollTop);
-
-      scrollHeight - scrollTop <= 1 + clientHeight
-        ? setIsScrollBottom(true)
-        : setIsScrollBottom(false);
-    }
-  };
+  const [isScrollBottom, onScroll, scrollRef, scrollTop] = useScroll();
 
   return (
     <>

--- a/pokemon-app/src/components/EnemyPokemon.js
+++ b/pokemon-app/src/components/EnemyPokemon.js
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
 import fightPad from "../assets/fightpad.png";
 import "../styles/EnemyPokemon.css";
 import ThemeSongs from "./ThemeSongs";
@@ -8,6 +8,22 @@ import PokemonCry from "./PokemonCry";
 
 const EnemyPokemon = ({ enemyPokemon, hasEnemy }) => {
   const [enemyStatsOnTop, setEnemyStatsOnTop] = useState(true);
+  const [scrollTop, setScrollTop] = useState(0);
+  const [isScrollBottom, setIsScrollBottom] = useState(false);
+
+  const scrollRef = useRef();
+
+  const onScroll = () => {
+    if (scrollRef.current) {
+      const { clientHeight, scrollHeight, scrollTop } = scrollRef.current;
+
+      setScrollTop(scrollTop);
+
+      scrollHeight - scrollTop === clientHeight
+        ? setIsScrollBottom(true)
+        : setIsScrollBottom(false);
+    }
+  };
 
   return (
     <>
@@ -70,6 +86,8 @@ const EnemyPokemon = ({ enemyPokemon, hasEnemy }) => {
               className={`enemy-pokemon__moves ${
                 enemyStatsOnTop ? "" : "on-top"
               }`}
+              ref={scrollRef}
+              onScroll={onScroll}
             >
               <ol className="enemy-pokemon__moves-list">
                 {!enemyPokemon?.moves
@@ -77,6 +95,16 @@ const EnemyPokemon = ({ enemyPokemon, hasEnemy }) => {
                   : enemyPokemon?.moves.map((moveData, moveIndex) => (
                       <li key={moveIndex}>{moveData.move.name}</li>
                     ))}
+
+                {!enemyPokemon?.moves ? null : !(scrollTop > 0) ? null : (
+                  <span className="enemy-moves-list--up-arrow"></span>
+                )}
+
+                {!enemyPokemon?.moves ? null : !(
+                    enemyPokemon?.moves.length > 7
+                  ) || isScrollBottom ? null : (
+                  <span className="enemy-moves-list--down-arrow"></span>
+                )}
               </ol>
             </div>
           </div>

--- a/pokemon-app/src/components/SinglePokemon.js
+++ b/pokemon-app/src/components/SinglePokemon.js
@@ -7,7 +7,8 @@ import ThemeSongs from "./ThemeSongs";
 import homeSong from "../assets/homeSong.mp3";
 import Types from "./Types";
 import PokemonCry from "./PokemonCry";
-import { useState, useRef } from "react";
+import { useState } from "react";
+import { useScroll } from "../hooks";
 
 const SinglePokemon = ({
   pokemon,
@@ -17,29 +18,7 @@ const SinglePokemon = ({
   isPokeballRendering,
 }) => {
   const [statsOnTop, setStatsOnTop] = useState(false);
-  const [scrollTop, setScrollTop] = useState(0);
-  const [isScrollBottom, setIsScrollBottom] = useState(false);
-  // This reference would be used for the moves-list scrollbar
-  // in order to get the scrollTop and calculate the bottom scroll.
-  const scrollRef = useRef();
-
-  const onScroll = () => {
-    // Always check if current exists before doing anything.
-    if (scrollRef.current) {
-      // Destructure these bad boys.
-      const { clientHeight, scrollHeight, scrollTop } = scrollRef.current;
-
-      // Set the integer value on how far the scrollbar is from the top,
-      // and this would be used to render the up-arrow for moves-list.
-      setScrollTop(scrollTop);
-
-      // Calculate if the scrollbar is at the bottom,
-      // and if it is then truthy; else, falsy
-      scrollHeight - scrollTop <= 1 + clientHeight
-        ? setIsScrollBottom(true)
-        : setIsScrollBottom(false);
-    }
-  };
+  const [isScrollBottom, onScroll, scrollRef, scrollTop] = useScroll();
 
   return (
     <>

--- a/pokemon-app/src/components/SinglePokemon.js
+++ b/pokemon-app/src/components/SinglePokemon.js
@@ -113,12 +113,20 @@ const SinglePokemon = ({
                       ))}
 
                   {!pokemon?.moves ? null : !(scrollTop > 0) ? null : (
-                    <span className="moves-list--up-arrow"></span>
+                    <span
+                      className={`moves-list--up-arrow ${
+                        hasEnemy ? "has-enemy" : ""
+                      }`}
+                    ></span>
                   )}
 
                   {!pokemon?.moves ? null : !(pokemon?.moves.length > 7) ||
                     isScrollBottom ? null : (
-                    <span className="moves-list--down-arrow"></span>
+                    <span
+                      className={`moves-list--down-arrow ${
+                        hasEnemy ? "has-enemy" : ""
+                      }`}
+                    ></span>
                   )}
                 </ol>
               </div>

--- a/pokemon-app/src/components/SinglePokemon.js
+++ b/pokemon-app/src/components/SinglePokemon.js
@@ -35,7 +35,7 @@ const SinglePokemon = ({
 
       // Calculate if the scrollbar is at the bottom,
       // and if it is then truthy; else, falsy
-      scrollHeight - scrollTop === clientHeight
+      scrollHeight - scrollTop <= 1 + clientHeight
         ? setIsScrollBottom(true)
         : setIsScrollBottom(false);
     }

--- a/pokemon-app/src/components/SinglePokemon.js
+++ b/pokemon-app/src/components/SinglePokemon.js
@@ -7,7 +7,7 @@ import ThemeSongs from "./ThemeSongs";
 import homeSong from "../assets/homeSong.mp3";
 import Types from "./Types";
 import PokemonCry from "./PokemonCry";
-import { useState } from "react";
+import { useState, useRef } from "react";
 
 const SinglePokemon = ({
   pokemon,
@@ -17,6 +17,29 @@ const SinglePokemon = ({
   isPokeballRendering,
 }) => {
   const [statsOnTop, setStatsOnTop] = useState(false);
+  const [scrollTop, setScrollTop] = useState(0);
+  const [isScrollBottom, setIsScrollBottom] = useState(false);
+  // This reference would be used for the moves-list scrollbar
+  // in order to get the scrollTop and calculate the bottom scroll.
+  const scrollRef = useRef();
+
+  const onScroll = () => {
+    // Always check if current exists before doing anything.
+    if (scrollRef.current) {
+      // Destructure these bad boys.
+      const { clientHeight, scrollHeight, scrollTop } = scrollRef.current;
+
+      // Set the integer value on how far the scrollbar is from the top,
+      // and this would be used to render the up-arrow for moves-list.
+      setScrollTop(scrollTop);
+
+      // Calculate if the scrollbar is at the bottom,
+      // and if it is then truthy; else, faslsy
+      scrollHeight - scrollTop === clientHeight
+        ? setIsScrollBottom(true)
+        : setIsScrollBottom(false);
+    }
+  };
 
   return (
     <>
@@ -79,6 +102,8 @@ const SinglePokemon = ({
                 className={`moves-box ${hasEnemy ? "has-enemy" : ""} ${
                   statsOnTop ? "" : "on-top"
                 }`}
+                ref={scrollRef}
+                onScroll={onScroll}
               >
                 <ol id="moves-list">
                   {!pokemon?.moves
@@ -87,9 +112,12 @@ const SinglePokemon = ({
                         <li key={moveIndex}>{moveData.move.name}</li>
                       ))}
 
-                  {!pokemon?.moves ? null : !(
-                      pokemon?.moves.length > 7
-                    ) ? null : (
+                  {!pokemon?.moves ? null : !(scrollTop > 0) ? null : (
+                    <span className="moves-list--up-arrow"></span>
+                  )}
+
+                  {!pokemon?.moves ? null : !(pokemon?.moves.length > 7) ||
+                    isScrollBottom ? null : (
                     <span className="moves-list--down-arrow"></span>
                   )}
                 </ol>

--- a/pokemon-app/src/components/SinglePokemon.js
+++ b/pokemon-app/src/components/SinglePokemon.js
@@ -34,7 +34,7 @@ const SinglePokemon = ({
       setScrollTop(scrollTop);
 
       // Calculate if the scrollbar is at the bottom,
-      // and if it is then truthy; else, faslsy
+      // and if it is then truthy; else, falsy
       scrollHeight - scrollTop === clientHeight
         ? setIsScrollBottom(true)
         : setIsScrollBottom(false);

--- a/pokemon-app/src/components/SinglePokemon.js
+++ b/pokemon-app/src/components/SinglePokemon.js
@@ -86,6 +86,12 @@ const SinglePokemon = ({
                     : pokemon?.moves.map((moveData, moveIndex) => (
                         <li key={moveIndex}>{moveData.move.name}</li>
                       ))}
+
+                  {!pokemon?.moves ? null : !(
+                      pokemon?.moves.length > 7
+                    ) ? null : (
+                    <span className="moves-list--down-arrow"></span>
+                  )}
                 </ol>
               </div>
             </div>

--- a/pokemon-app/src/hooks/index.js
+++ b/pokemon-app/src/hooks/index.js
@@ -1,0 +1,3 @@
+import useScroll from "./useScroll";
+
+export { useScroll };

--- a/pokemon-app/src/hooks/useScroll.js
+++ b/pokemon-app/src/hooks/useScroll.js
@@ -1,0 +1,39 @@
+import { useRef, useState } from "react";
+
+/**
+ * Calculates the top scroll and bottom scroll.
+ * @returns {[isScrollBottom,onScroll,scrollRef,scrollTop]} An array that contains isScrollBottom, onScroll, scrollRef, and scrollTop
+ */
+const useScroll = () => {
+  // This would be used to set the integer value on how far it is
+  // from the top.
+  const [scrollTop, setScrollTop] = useState(0);
+  // This would be used to set a boolean value based if it is at the
+  // bottom.
+  const [isScrollBottom, setIsScrollBottom] = useState(false);
+  // This reference would be used in order to get the scrollTop
+  // and calculate the bottom scroll.
+  const scrollRef = useRef();
+
+  const onScroll = () => {
+    // Always check if current exists before doing anything.
+    if (scrollRef.current) {
+      // Destructure these bad boys.
+      const { clientHeight, scrollHeight, scrollTop } = scrollRef.current;
+
+      // Set the integer value on how far the scrollbar is from the top,
+      // and this would be used to render the up-arrow for moves-list.
+      setScrollTop(scrollTop);
+
+      // Calculate if the scrollbar is at the bottom,
+      // and if it is then truthy; else, falsy
+      scrollHeight - scrollTop <= 1 + clientHeight
+        ? setIsScrollBottom(true)
+        : setIsScrollBottom(false);
+    }
+  };
+
+  return [isScrollBottom, onScroll, scrollRef, scrollTop];
+};
+
+export default useScroll;

--- a/pokemon-app/src/styles/EnemyPokemon.css
+++ b/pokemon-app/src/styles/EnemyPokemon.css
@@ -146,7 +146,7 @@
   animation-duration: 0.8s;
   animation-iteration-count: infinite;
   animation-timing-function: ease-in-out;
-  animation-name: uparrowmoves;
+  animation-name: uparrowmovesenemy;
 }
 
 .enemy-moves-list--down-arrow {
@@ -161,7 +161,7 @@
   animation-duration: 0.8s;
   animation-iteration-count: infinite;
   animation-timing-function: ease-in-out;
-  animation-name: downarrowmoves;
+  animation-name: downarrowmovesenemy;
 }
 
 /**************/
@@ -169,7 +169,7 @@
 /**************/
 
 /* ENEMY-MOVES-LIST ARROWS MOVES */
-@keyframes uparrowmoves {
+@keyframes uparrowmovesenemy {
   from {
     top: 14%;
   }
@@ -179,7 +179,7 @@
   }
 }
 
-@keyframes downarrowmoves {
+@keyframes downarrowmovesenemy {
   from {
     top: 35.3%;
   }

--- a/pokemon-app/src/styles/EnemyPokemon.css
+++ b/pokemon-app/src/styles/EnemyPokemon.css
@@ -49,7 +49,8 @@
   width: 100%;
   height: 95%;
 }
-.enemy-pokemon__moves-title, .enemy-pokemon__stats-title{
+.enemy-pokemon__moves-title,
+.enemy-pokemon__stats-title {
   position: absolute;
   font-size: 1.8em;
   border: solid black 6px;
@@ -60,13 +61,14 @@
   top: 3%;
   z-index: 2;
 }
-.enemy-pokemon__stats-title{
+.enemy-pokemon__stats-title {
   left: 27%;
   background-color: rgb(160, 212, 212);
   z-index: 0;
 }
 
-.enemy-pokemon__stats, .enemy-pokemon__moves {
+.enemy-pokemon__stats,
+.enemy-pokemon__moves {
   z-index: 1;
   box-sizing: border-box;
   font-size: 1em;
@@ -82,39 +84,44 @@
   padding-top: 2%;
   box-shadow: 0.3em 0.3em rgba(0, 0, 0, 0.3);
 }
-.enemy-pokemon__stats{
+.enemy-pokemon__stats {
   background-color: rgb(160, 212, 212);
   z-index: 0;
 }
-.enemy-pokemon__stats::-webkit-scrollbar, .enemy-pokemon__moves::-webkit-scrollbar {
+.enemy-pokemon__stats::-webkit-scrollbar,
+.enemy-pokemon__moves::-webkit-scrollbar {
   width: 8.6px;
   height: 7.6px;
 }
-.enemy-pokemon__stats::-webkit-scrollbar-track, .enemy-pokemon__moves::-webkit-scrollbar-track {
+.enemy-pokemon__stats::-webkit-scrollbar-track,
+.enemy-pokemon__moves::-webkit-scrollbar-track {
   background: transparent;
 }
-.enemy-pokemon__stats::-webkit-scrollbar-thumb, .enemy-pokemon__moves::-webkit-scrollbar-thumb {
+.enemy-pokemon__stats::-webkit-scrollbar-thumb,
+.enemy-pokemon__moves::-webkit-scrollbar-thumb {
   background-color: rgba(0, 0, 0, 0.18);
   border-radius: 50px;
   border: 1px solid rgba(0, 0, 0, 0.5);
 }
-.on-tip-top{
+.on-tip-top {
   z-index: 4;
 }
-.on-top{
+.on-top {
   z-index: 3;
 }
 
-.enemy-pokemon__stats-list, .enemy-pokemon__moves-list{
+.enemy-pokemon__stats-list,
+.enemy-pokemon__moves-list {
   margin: 5px;
 }
 
-.enemy-pokemon__stats-list > li , .enemy-pokemon__moves-list > li {
+.enemy-pokemon__stats-list > li,
+.enemy-pokemon__moves-list > li {
   font-size: 1em;
   margin: 10px;
 }
 
-.enemy-pokemon-types{
+.enemy-pokemon-types {
   z-index: 2;
   position: absolute;
   top: 34%;
@@ -122,6 +129,62 @@
   transform: scale(1.4);
 }
 
-.enemy-pokemon__moves-title:hover, .enemy-pokemon__stats-title:hover {
+.enemy-pokemon__moves-title:hover,
+.enemy-pokemon__stats-title:hover {
   cursor: pointer;
+}
+
+.enemy-moves-list--up-arrow {
+  position: fixed;
+  top: 14%;
+  left: 49%;
+  width: 0;
+  height: 0;
+  border-left: 7px solid transparent;
+  border-right: 7px solid transparent;
+  border-bottom: 7px solid #b11501;
+  animation-duration: 0.8s;
+  animation-iteration-count: infinite;
+  animation-timing-function: ease-in-out;
+  animation-name: uparrowmoves;
+}
+
+.enemy-moves-list--down-arrow {
+  position: fixed;
+  top: 35.3%;
+  left: 49%;
+  width: 0;
+  height: 0;
+  border-left: 7px solid transparent;
+  border-right: 7px solid transparent;
+  border-top: 7px solid #b11501;
+  animation-duration: 0.8s;
+  animation-iteration-count: infinite;
+  animation-timing-function: ease-in-out;
+  animation-name: downarrowmoves;
+}
+
+/**************/
+/* ANIMATIONS */
+/**************/
+
+/* ENEMY-MOVES-LIST ARROWS MOVES */
+@keyframes uparrowmoves {
+  from {
+    top: 14%;
+  }
+
+  to {
+    top: 13.7%;
+  }
+}
+
+@keyframes downarrowmoves {
+  from {
+    top: 35.3%;
+  }
+
+  to {
+    top: 35.7%;
+  }
 }

--- a/pokemon-app/src/styles/One-pokemon-page.css
+++ b/pokemon-app/src/styles/One-pokemon-page.css
@@ -137,54 +137,32 @@
 
 .moves-list--up-arrow {
   position: fixed;
-  top: 13.6%;
+  top: 14.7%;
   right: 26.5%;
-  transform: rotate(-90deg);
-  width: 16px;
-  height: 16px;
-  border-radius: 50%;
-}
-.moves-list--up-arrow::before {
-  content: "";
-  display: block;
-  width: 1.5px;
-  height: 10.5px;
-  background-color: black;
-  transform: translate(10%, 20%) rotate(135deg);
-}
-.moves-list--up-arrow::after {
-  content: "";
-  display: block;
-  width: 1.5px;
-  height: 10.5px;
-  background-color: black;
-  transform: translate(10%, -20%) rotate(45deg);
+  width: 0;
+  height: 0;
+  border-left: 7px solid transparent;
+  border-right: 7px solid transparent;
+  border-bottom: 7px solid #b11501;
+  animation-duration: 0.8s;
+  animation-iteration-count: infinite;
+  animation-timing-function: ease-in-out;
+  animation-name: uparrowmoves;
 }
 
 .moves-list--down-arrow {
   position: fixed;
-  top: 36.2%;
-  right: 26.2%;
-  transform: rotate(90deg);
-  width: 16px;
-  height: 16px;
-  border-radius: 50%;
-}
-.moves-list--down-arrow::before {
-  content: "";
-  display: block;
-  width: 1.5px;
-  height: 10.5px;
-  background-color: black;
-  transform: translate(10%, 20%) rotate(135deg);
-}
-.moves-list--down-arrow::after {
-  content: "";
-  display: block;
-  width: 1.5px;
-  height: 10.5px;
-  background-color: black;
-  transform: translate(10%, -20%) rotate(45deg);
+  top: 36%;
+  right: 26.5%;
+  width: 0;
+  height: 0;
+  border-left: 7px solid transparent;
+  border-right: 7px solid transparent;
+  border-top: 7px solid #b11501;
+  animation-duration: 0.8s;
+  animation-iteration-count: infinite;
+  animation-timing-function: ease-in-out;
+  animation-name: downarrowmoves;
 }
 
 .pokemon-types {
@@ -197,4 +175,29 @@
 .pokemon-types.has-enemy {
   top: 90%;
   left: 18%;
+}
+
+/**************/
+/* ANIMATIONS */
+/**************/
+
+/* MOVES-LIST ARROWS MOVES */
+@keyframes uparrowmoves {
+  from {
+    top: 14.7%;
+  }
+
+  to {
+    top: 14.3%;
+  }
+}
+
+@keyframes downarrowmoves {
+  from {
+    top: 36%;
+  }
+
+  to {
+    top: 36.4%;
+  }
 }

--- a/pokemon-app/src/styles/One-pokemon-page.css
+++ b/pokemon-app/src/styles/One-pokemon-page.css
@@ -135,6 +135,32 @@
   margin: 10px;
 }
 
+.moves-list--up-arrow {
+  position: fixed;
+  top: 13.6%;
+  right: 26.5%;
+  transform: rotate(-90deg);
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+}
+.moves-list--up-arrow::before {
+  content: "";
+  display: block;
+  width: 1.5px;
+  height: 10.5px;
+  background-color: black;
+  transform: translate(10%, 20%) rotate(135deg);
+}
+.moves-list--up-arrow::after {
+  content: "";
+  display: block;
+  width: 1.5px;
+  height: 10.5px;
+  background-color: black;
+  transform: translate(10%, -20%) rotate(45deg);
+}
+
 .moves-list--down-arrow {
   position: fixed;
   top: 36.2%;

--- a/pokemon-app/src/styles/One-pokemon-page.css
+++ b/pokemon-app/src/styles/One-pokemon-page.css
@@ -52,7 +52,8 @@
 .poke-pad.has-enemy {
   top: 76%;
 }
-.moves-title, .stats-title{
+.moves-title,
+.stats-title {
   position: absolute;
   font-size: 1.8em;
   border: solid black 6px;
@@ -63,18 +64,21 @@
   top: 4.5%;
   z-index: 2;
 }
-.stats-title{
+.stats-title {
   right: 3%;
   background-color: rgb(160, 212, 212);
   z-index: 0;
 }
-.moves-title.has-enemy, .stats-title.has-enemy{
+.moves-title.has-enemy,
+.stats-title.has-enemy {
   top: 55%;
 }
-.moves-title:hover, .stats-title:hover {
+.moves-title:hover,
+.stats-title:hover {
   cursor: pointer;
 }
-.stats-box, .moves-box{
+.stats-box,
+.moves-box {
   z-index: 1;
   box-sizing: border-box;
   font-size: 1em;
@@ -90,49 +94,81 @@
   padding-top: 2%;
   box-shadow: 0.3em 0.3em rgba(0, 0, 0, 0.3);
 }
-.stats-box{
+.stats-box {
   background-color: rgb(160, 212, 212);
   z-index: 0;
 }
-.on-tip-top{
+.on-tip-top {
   z-index: 4;
 }
-.on-top{
+.on-top {
   z-index: 3;
 }
-.stats-box.has-enemy, .moves-box.has-enemy {
+.stats-box.has-enemy,
+.moves-box.has-enemy {
   top: 61%;
 }
-.stats-box::-webkit-scrollbar, .moves-box::-webkit-scrollbar {
+.stats-box::-webkit-scrollbar,
+.moves-box::-webkit-scrollbar {
   width: 8.6px;
   height: 7.6px;
 }
-.stats-box::-webkit-scrollbar-track, .moves-box::-webkit-scrollbar-track {
+.stats-box::-webkit-scrollbar-track,
+.moves-box::-webkit-scrollbar-track {
   background: transparent;
 }
-.stats-box::-webkit-scrollbar-thumb, .moves-box::-webkit-scrollbar-thumb {
+.stats-box::-webkit-scrollbar-thumb,
+.moves-box::-webkit-scrollbar-thumb {
   background-color: rgba(0, 0, 0, 0.18);
   border-radius: 50px;
   border: 1px solid rgba(0, 0, 0, 0.5);
 }
 
-#stats-list, #moves-list{
+#stats-list,
+#moves-list {
   margin: 5px;
 }
 
-#stats-list > li , #moves-list > li {
+#stats-list > li,
+#moves-list > li {
   font-size: 1em;
   margin: 10px;
 }
 
-.pokemon-types{
+.moves-list--down-arrow {
+  position: fixed;
+  top: 36.2%;
+  right: 26.2%;
+  transform: rotate(90deg);
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+}
+.moves-list--down-arrow::before {
+  content: "";
+  display: block;
+  width: 1.5px;
+  height: 10.5px;
+  background-color: black;
+  transform: translate(10%, 20%) rotate(135deg);
+}
+.moves-list--down-arrow::after {
+  content: "";
+  display: block;
+  width: 1.5px;
+  height: 10.5px;
+  background-color: black;
+  transform: translate(10%, -20%) rotate(45deg);
+}
+
+.pokemon-types {
   z-index: 2;
   position: absolute;
   top: 35%;
   left: 18%;
   transform: scale(1.4);
 }
-.pokemon-types.has-enemy{
+.pokemon-types.has-enemy {
   top: 90%;
   left: 18%;
 }

--- a/pokemon-app/src/styles/One-pokemon-page.css
+++ b/pokemon-app/src/styles/One-pokemon-page.css
@@ -149,6 +149,20 @@
   animation-timing-function: ease-in-out;
   animation-name: uparrowmoves;
 }
+.moves-list--up-arrow.has-enemy {
+  position: fixed;
+  top: 53.5%;
+  right: 26.5%;
+  width: 0;
+  height: 0;
+  border-left: 7px solid transparent;
+  border-right: 7px solid transparent;
+  border-bottom: 7px solid #b11501;
+  animation-duration: 0.8s;
+  animation-iteration-count: infinite;
+  animation-timing-function: ease-in-out;
+  animation-name: uparrowmoves2;
+}
 
 .moves-list--down-arrow {
   position: fixed;
@@ -163,6 +177,20 @@
   animation-iteration-count: infinite;
   animation-timing-function: ease-in-out;
   animation-name: downarrowmoves;
+}
+.moves-list--down-arrow.has-enemy {
+  position: fixed;
+  top: 74.8%;
+  right: 26.5%;
+  width: 0;
+  height: 0;
+  border-left: 7px solid transparent;
+  border-right: 7px solid transparent;
+  border-top: 7px solid #b11501;
+  animation-duration: 0.8s;
+  animation-iteration-count: infinite;
+  animation-timing-function: ease-in-out;
+  animation-name: downarrowmoves2;
 }
 
 .pokemon-types {
@@ -191,6 +219,15 @@
     top: 14.3%;
   }
 }
+@keyframes uparrowmoves2 {
+  from {
+    top: 53.5%;
+  }
+
+  to {
+    top: 53.1%;
+  }
+}
 
 @keyframes downarrowmoves {
   from {
@@ -199,5 +236,14 @@
 
   to {
     top: 36.4%;
+  }
+}
+@keyframes downarrowmoves2 {
+  from {
+    top: 74.8%;
+  }
+
+  to {
+    top: 75.2%;
   }
 }


### PR DESCRIPTION
## Changes
1. Create a custom hook for scrolling in useScroll.js.
2. Used useScroll hook with isScrollBottom, onScroll, scrollRef, and scrollTop in SinglePokemon.js.
3. Used useScroll hook with isScrollBottom, onScroll, scrollRef, and scrollTop in EnemyPokemon.js.
4. Styled the up-arrow and down-arrow with animations.

## Purpose
The problem was that there were no indications to the user that they could scroll down when the pokemon has more than seven moves.

## Approach
The first solution would be to create and style the up and down arrows. The second solution would be to only show the up-arrow if the user has scrolled, and to not show the down-arrow if the user has reached the bottom. An approach to this would be to use a `useRef` hook and place it where the move-list element has a CSS property of `overflow-y: auto`, and create an `onScroll` event on that element. From there the calculations for the bottom scroll and top scroll could be achieved solving the dynamic rendering of the top-arrow and down-arrow. Lastly, I created a custom hook called `useScroll` that implements these functionalities in order to reduce code since it was used both in `SinglePokemon.js` and `EnemyPokemon.js`. Overall, this gives a better and engaging UI experience.

## Screenshots
![ezgif com-gif-maker (6)](https://user-images.githubusercontent.com/29642735/127569892-33504b46-69da-4957-a9cb-f549e6492d91.gif)


Closes #59 