### PR TITLE
Eg 68 fix movelists arrows

### DIFF
--- a/pokemon-app/src/components/EnemyPokemon.js
+++ b/pokemon-app/src/components/EnemyPokemon.js
@@ -81,18 +81,18 @@ const EnemyPokemon = ({ enemyPokemon, hasEnemy }) => {
                   : enemyPokemon?.moves.map((moveData, moveIndex) => (
                       <li key={moveIndex}>{moveData.move.name}</li>
                     ))}
-
-                {!enemyPokemon?.moves ? null : !(scrollTop > 0) ? null : (
-                  <span className="enemy-moves-list--up-arrow"></span>
-                )}
-
-                {!enemyPokemon?.moves ? null : !(
-                    enemyPokemon?.moves.length > 7
-                  ) || isScrollBottom ? null : (
-                  <span className="enemy-moves-list--down-arrow"></span>
-                )}
               </ol>
             </div>
+
+            {!enemyPokemon?.moves ? null : !(scrollTop > 0) ? null : (
+              <span className="enemy-moves-list--up-arrow"></span>
+            )}
+
+            {!enemyPokemon?.moves ? null : !(enemyPokemon?.moves.length > 7) ||
+              isScrollBottom ? null : (
+              <span className="enemy-moves-list--down-arrow"></span>
+            )}
+
             <div className="enemy-poke">Enemy Pokemon</div>
           </div>
 

--- a/pokemon-app/src/components/EnemyPokemon.js
+++ b/pokemon-app/src/components/EnemyPokemon.js
@@ -11,6 +11,45 @@ const EnemyPokemon = ({ enemyPokemon, hasEnemy }) => {
   const [enemyStatsOnTop, setEnemyStatsOnTop] = useState(true);
   const [isScrollBottom, onScroll, scrollRef, scrollTop] = useScroll();
 
+  // This checks if the moves property exist in pokemon object.
+  const checkDoesMovesKeyExistInObject = () =>
+    Object.prototype.hasOwnProperty.call(enemyPokemon, "moves");
+  // This checks if the moves list length is less than or equal to 7.
+  const checkIsMovesListLengthSevenOrLess = () =>
+    enemyPokemon?.moves.length <= 7;
+  // This checks if the stats list has been selected.
+  const checkIsStatsListSelected = () => enemyStatsOnTop;
+  // This checks if the scrollbar is at the top.
+  const checkIsScrollbarAtTop = () => scrollTop < 1;
+  // This checks if the scrollbar is at the bottom.
+  const checkIsScrollbarAtBottom = () => isScrollBottom;
+
+  /**
+   * To render the top-arrow, this function checks to see if the pokemon moves exist AND the scrollbar is not at the top AND the stats list has not been selected.
+   * @returns {boolean} A boolean.
+   */
+  const renderMovesListTopArrow = () =>
+    // True if the moves property exist in pokemon object.
+    checkDoesMovesKeyExistInObject() &&
+    // True if the scrollbar is not at the top.
+    !checkIsScrollbarAtTop() &&
+    // True if the stats list has not been selected.
+    !checkIsStatsListSelected();
+
+  /**
+   * To render the bottom-arrow, this function checks to see if the pokemon moves exist AND its moves length is not seven or less AND the scrollbar is not at the bottom AND the stats list has not been selected.
+   * @returns {boolean} A boolean.
+   */
+  const renderMovesListBottomArrow = () =>
+    // True if the moves property exist in pokemon object.
+    checkDoesMovesKeyExistInObject() &&
+    // True if the moves length is greater than seven.
+    !checkIsMovesListLengthSevenOrLess() &&
+    // True if the scrollbar is not at the bottom.
+    !checkIsScrollbarAtBottom() &&
+    // True if the stats list has not been selected.
+    !checkIsStatsListSelected();
+
   return (
     <>
       {!enemyPokemon ? null : (
@@ -84,14 +123,11 @@ const EnemyPokemon = ({ enemyPokemon, hasEnemy }) => {
               </ol>
             </div>
 
-            {!enemyPokemon?.moves ? null : !(scrollTop > 0) ||
-              enemyStatsOnTop ? null : (
+            {renderMovesListTopArrow() && (
               <span className="enemy-moves-list--up-arrow"></span>
             )}
 
-            {!enemyPokemon?.moves ? null : !(enemyPokemon?.moves.length > 7) ||
-              isScrollBottom ||
-              enemyStatsOnTop ? null : (
+            {renderMovesListBottomArrow() && (
               <span className="enemy-moves-list--down-arrow"></span>
             )}
 

--- a/pokemon-app/src/components/EnemyPokemon.js
+++ b/pokemon-app/src/components/EnemyPokemon.js
@@ -84,12 +84,14 @@ const EnemyPokemon = ({ enemyPokemon, hasEnemy }) => {
               </ol>
             </div>
 
-            {!enemyPokemon?.moves ? null : !(scrollTop > 0) ? null : (
+            {!enemyPokemon?.moves ? null : !(scrollTop > 0) ||
+              enemyStatsOnTop ? null : (
               <span className="enemy-moves-list--up-arrow"></span>
             )}
 
             {!enemyPokemon?.moves ? null : !(enemyPokemon?.moves.length > 7) ||
-              isScrollBottom ? null : (
+              isScrollBottom ||
+              enemyStatsOnTop ? null : (
               <span className="enemy-moves-list--down-arrow"></span>
             )}
 

--- a/pokemon-app/src/components/SinglePokemon.js
+++ b/pokemon-app/src/components/SinglePokemon.js
@@ -20,6 +20,44 @@ const SinglePokemon = ({
   const [statsOnTop, setStatsOnTop] = useState(false);
   const [isScrollBottom, onScroll, scrollRef, scrollTop] = useScroll();
 
+  // This checks if the moves property exist in pokemon object.
+  const checkDoesMovesKeyExistInObject = () =>
+    Object.prototype.hasOwnProperty.call(pokemon, "moves");
+  // This checks if the moves list length is less than or equal to 7.
+  const checkIsMovesListLengthSevenOrLess = () => pokemon?.moves.length <= 7;
+  // This checks if the stats list has been selected.
+  const checkIsStatsListSelected = () => statsOnTop;
+  // This checks if the scrollbar is at the top.
+  const checkIsScrollbarAtTop = () => scrollTop < 1;
+  // This checks if the scrollbar is at the bottom.
+  const checkIsScrollbarAtBottom = () => isScrollBottom;
+
+  /**
+   * To render the top-arrow, this function checks to see if the pokemon moves exist AND the scrollbar is not at the top AND the stats list has not been selected.
+   * @returns {boolean} A boolean.
+   */
+  const renderMovesListTopArrow = () =>
+    // True if the moves property exist in pokemon object.
+    checkDoesMovesKeyExistInObject() &&
+    // True if the scrollbar is not at the top.
+    !checkIsScrollbarAtTop() &&
+    // True if the stats list has not been selected.
+    !checkIsStatsListSelected();
+
+  /**
+   * To render the bottom-arrow, this function checks to see if the pokemon moves exist AND its moves length is not seven or less AND the scrollbar is not at the bottom AND the stats list has not been selected.
+   * @returns {boolean} A boolean.
+   */
+  const renderMovesListBottomArrow = () =>
+    // True if the moves property exist in pokemon object.
+    checkDoesMovesKeyExistInObject() &&
+    // True if the moves length is greater than seven.
+    !checkIsMovesListLengthSevenOrLess() &&
+    // True if the scrollbar is not at the bottom.
+    !checkIsScrollbarAtBottom() &&
+    // True if the stats list has not been selected.
+    !checkIsStatsListSelected();
+
   return (
     <>
       {!pokemon ? null : (
@@ -96,8 +134,7 @@ const SinglePokemon = ({
                 </ol>
               </div>
 
-              {!pokemon?.moves ? null : !(scrollTop > 0) ||
-                statsOnTop ? null : (
+              {renderMovesListTopArrow() && (
                 <span
                   className={`moves-list--up-arrow ${
                     hasEnemy ? "has-enemy" : ""
@@ -105,9 +142,7 @@ const SinglePokemon = ({
                 ></span>
               )}
 
-              {!pokemon?.moves ? null : !(pokemon?.moves.length > 7) ||
-                isScrollBottom ||
-                statsOnTop ? null : (
+              {renderMovesListBottomArrow() && (
                 <span
                   className={`moves-list--down-arrow ${
                     hasEnemy ? "has-enemy" : ""

--- a/pokemon-app/src/components/SinglePokemon.js
+++ b/pokemon-app/src/components/SinglePokemon.js
@@ -96,7 +96,8 @@ const SinglePokemon = ({
                 </ol>
               </div>
 
-              {!pokemon?.moves ? null : !(scrollTop > 0) ? null : (
+              {!pokemon?.moves ? null : !(scrollTop > 0) ||
+                statsOnTop ? null : (
                 <span
                   className={`moves-list--up-arrow ${
                     hasEnemy ? "has-enemy" : ""
@@ -105,7 +106,8 @@ const SinglePokemon = ({
               )}
 
               {!pokemon?.moves ? null : !(pokemon?.moves.length > 7) ||
-                isScrollBottom ? null : (
+                isScrollBottom ||
+                statsOnTop ? null : (
                 <span
                   className={`moves-list--down-arrow ${
                     hasEnemy ? "has-enemy" : ""

--- a/pokemon-app/src/components/SinglePokemon.js
+++ b/pokemon-app/src/components/SinglePokemon.js
@@ -76,7 +76,9 @@ const SinglePokemon = ({
                       ))}
                 </ol>
               </div>
-              <div className={hasEnemy ? "user-poke" : "user-poke-none"} >Your Pokemon</div>
+              <div className={hasEnemy ? "user-poke" : "user-poke-none"}>
+                Your Pokemon
+              </div>
 
               <div
                 className={`moves-box ${hasEnemy ? "has-enemy" : ""} ${
@@ -91,25 +93,25 @@ const SinglePokemon = ({
                     : pokemon?.moves.map((moveData, moveIndex) => (
                         <li key={moveIndex}>{moveData.move.name}</li>
                       ))}
-
-                  {!pokemon?.moves ? null : !(scrollTop > 0) ? null : (
-                    <span
-                      className={`moves-list--up-arrow ${
-                        hasEnemy ? "has-enemy" : ""
-                      }`}
-                    ></span>
-                  )}
-
-                  {!pokemon?.moves ? null : !(pokemon?.moves.length > 7) ||
-                    isScrollBottom ? null : (
-                    <span
-                      className={`moves-list--down-arrow ${
-                        hasEnemy ? "has-enemy" : ""
-                      }`}
-                    ></span>
-                  )}
                 </ol>
               </div>
+
+              {!pokemon?.moves ? null : !(scrollTop > 0) ? null : (
+                <span
+                  className={`moves-list--up-arrow ${
+                    hasEnemy ? "has-enemy" : ""
+                  }`}
+                ></span>
+              )}
+
+              {!pokemon?.moves ? null : !(pokemon?.moves.length > 7) ||
+                isScrollBottom ? null : (
+                <span
+                  className={`moves-list--down-arrow ${
+                    hasEnemy ? "has-enemy" : ""
+                  }`}
+                ></span>
+              )}
             </div>
             <div className={`pokemon-types ${hasEnemy ? "has-enemy" : ""}`}>
               <Types pokemon={pokemon} />

--- a/pokemon-app/src/styles/EnemyPokemon.css
+++ b/pokemon-app/src/styles/EnemyPokemon.css
@@ -168,14 +168,15 @@
 }
 
 .enemy-moves-list--up-arrow {
-  position: fixed;
-  top: 14%;
-  left: 49%;
+  position: absolute;
+  top: 11%;
+  left: 45.5%;
   width: 0;
   height: 0;
   border-left: 7px solid transparent;
   border-right: 7px solid transparent;
   border-bottom: 7px solid #b11501;
+  z-index: 100;
   animation-duration: 0.8s;
   animation-iteration-count: infinite;
   animation-timing-function: ease-in-out;
@@ -183,14 +184,15 @@
 }
 
 .enemy-moves-list--down-arrow {
-  position: fixed;
-  top: 35.3%;
-  left: 49%;
+  position: absolute;
+  top: 38%;
+  left: 45.5%;
   width: 0;
   height: 0;
   border-left: 7px solid transparent;
   border-right: 7px solid transparent;
   border-top: 7px solid #b11501;
+  z-index: 100;
   animation-duration: 0.8s;
   animation-iteration-count: infinite;
   animation-timing-function: ease-in-out;
@@ -204,20 +206,20 @@
 /* ENEMY-MOVES-LIST ARROWS MOVES */
 @keyframes uparrowmovesenemy {
   from {
-    top: 14%;
+    top: 11%;
   }
 
   to {
-    top: 13.7%;
+    top: 10.6%;
   }
 }
 
 @keyframes downarrowmovesenemy {
   from {
-    top: 35.3%;
+    top: 38%;
   }
 
   to {
-    top: 35.7%;
+    top: 38.4%;
   }
 }

--- a/pokemon-app/src/styles/EnemyPokemon.css
+++ b/pokemon-app/src/styles/EnemyPokemon.css
@@ -176,7 +176,7 @@
   border-left: 7px solid transparent;
   border-right: 7px solid transparent;
   border-bottom: 7px solid #b11501;
-  z-index: 100;
+  z-index: 3;
   animation-duration: 0.8s;
   animation-iteration-count: infinite;
   animation-timing-function: ease-in-out;
@@ -192,7 +192,7 @@
   border-left: 7px solid transparent;
   border-right: 7px solid transparent;
   border-top: 7px solid #b11501;
-  z-index: 100;
+  z-index: 3;
   animation-duration: 0.8s;
   animation-iteration-count: infinite;
   animation-timing-function: ease-in-out;

--- a/pokemon-app/src/styles/One-pokemon-page.css
+++ b/pokemon-app/src/styles/One-pokemon-page.css
@@ -144,7 +144,7 @@
   border-left: 7px solid transparent;
   border-right: 7px solid transparent;
   border-bottom: 7px solid #b11501;
-  z-index: 100;
+  z-index: 3;
   animation-duration: 0.8s;
   animation-iteration-count: infinite;
   animation-timing-function: ease-in-out;
@@ -159,7 +159,7 @@
   border-left: 7px solid transparent;
   border-right: 7px solid transparent;
   border-bottom: 7px solid #b11501;
-  z-index: 100;
+  z-index: 3;
   animation-duration: 0.8s;
   animation-iteration-count: infinite;
   animation-timing-function: ease-in-out;
@@ -175,7 +175,7 @@
   border-left: 7px solid transparent;
   border-right: 7px solid transparent;
   border-top: 7px solid #b11501;
-  z-index: 100;
+  z-index: 3;
   animation-duration: 0.8s;
   animation-iteration-count: infinite;
   animation-timing-function: ease-in-out;
@@ -190,7 +190,7 @@
   border-left: 7px solid transparent;
   border-right: 7px solid transparent;
   border-top: 7px solid #b11501;
-  z-index: 100;
+  z-index: 3;
   animation-duration: 0.8s;
   animation-iteration-count: infinite;
   animation-timing-function: ease-in-out;

--- a/pokemon-app/src/styles/One-pokemon-page.css
+++ b/pokemon-app/src/styles/One-pokemon-page.css
@@ -136,28 +136,30 @@
 }
 
 .moves-list--up-arrow {
-  position: fixed;
-  top: 14.7%;
-  right: 26.5%;
+  position: absolute;
+  top: 12%;
+  right: 5.5%;
   width: 0;
   height: 0;
   border-left: 7px solid transparent;
   border-right: 7px solid transparent;
   border-bottom: 7px solid #b11501;
+  z-index: 100;
   animation-duration: 0.8s;
   animation-iteration-count: infinite;
   animation-timing-function: ease-in-out;
   animation-name: uparrowmoves;
 }
 .moves-list--up-arrow.has-enemy {
-  position: fixed;
-  top: 53.5%;
-  right: 26.5%;
+  position: absolute;
+  top: 63%;
+  right: 5.5%;
   width: 0;
   height: 0;
   border-left: 7px solid transparent;
   border-right: 7px solid transparent;
   border-bottom: 7px solid #b11501;
+  z-index: 100;
   animation-duration: 0.8s;
   animation-iteration-count: infinite;
   animation-timing-function: ease-in-out;
@@ -165,28 +167,30 @@
 }
 
 .moves-list--down-arrow {
-  position: fixed;
-  top: 36%;
-  right: 26.5%;
+  position: absolute;
+  top: 39%;
+  right: 5.5%;
   width: 0;
   height: 0;
   border-left: 7px solid transparent;
   border-right: 7px solid transparent;
   border-top: 7px solid #b11501;
+  z-index: 100;
   animation-duration: 0.8s;
   animation-iteration-count: infinite;
   animation-timing-function: ease-in-out;
   animation-name: downarrowmoves;
 }
 .moves-list--down-arrow.has-enemy {
-  position: fixed;
-  top: 74.8%;
-  right: 26.5%;
+  position: absolute;
+  top: 90%;
+  right: 5.5%;
   width: 0;
   height: 0;
   border-left: 7px solid transparent;
   border-right: 7px solid transparent;
   border-top: 7px solid #b11501;
+  z-index: 100;
   animation-duration: 0.8s;
   animation-iteration-count: infinite;
   animation-timing-function: ease-in-out;
@@ -212,38 +216,38 @@
 /* MOVES-LIST ARROWS MOVES */
 @keyframes uparrowmoves {
   from {
-    top: 14.7%;
+    top: 12%;
   }
 
   to {
-    top: 14.3%;
+    top: 11.6%;
   }
 }
 @keyframes uparrowmoves2 {
   from {
-    top: 53.5%;
+    top: 63%;
   }
 
   to {
-    top: 53.1%;
+    top: 62.6%;
   }
 }
 
 @keyframes downarrowmoves {
   from {
-    top: 36%;
+    top: 39%;
   }
 
   to {
-    top: 36.4%;
+    top: 39.4%;
   }
 }
 @keyframes downarrowmoves2 {
   from {
-    top: 74.8%;
+    top: 90%;
   }
 
   to {
-    top: 75.2%;
+    top: 90.4%;
   }
 }


### PR DESCRIPTION
## Changes
1. Added another conditional to render the top and bottom arrows if the user has not select the stats option in SinglePokemon.js.
2. Refactored the conditional renderings for the top and bottom arrows into functions for readability in SinglePokemon.js.
3. Added another conditional to render the top and bottom arrows if the user has not select the stats option in EnemyPokemon.js.
4. Refactored the conditional renderings for the top and bottom arrows into functions for readability in EnemyPokemon.js.

## Purpose
The problem was that the arrows were not at their correct places based on their positioning property, and they were still seen when the user selects an the stats-list option.

## Approach
One way on fixing the arrow placements was to change their positioning property from `fixed` -> `absolute`. Then, place the `span` elements outside the moves-list `div` element since the CSS property of `overflow-y: auto` could interfere with the positioning property, and fix either their `top`, `left`, or `right` CSS properties. Lastly, the conditional renderings for the top and down arrows were hard to read, and thus were reduced into functions for readability.

## Final Note
As final note, the moves-list are used in both SinglePokemon and EnemyPokemon components, and to fix this duplication would be to create a MovesList component. This will be dealth with on Issue #70 .

## Screenshots
![review-the-pr-please](https://user-images.githubusercontent.com/29642735/127695952-fe79597b-cd40-4469-9629-8839fe37763e.gif)


Closes #68 