### PR TITLE
feat(moveslist-component): create a MovesList component; style the Mo…

### DIFF
--- a/pokemon-app/src/components/EnemyPokemon.js
+++ b/pokemon-app/src/components/EnemyPokemon.js
@@ -5,50 +5,14 @@ import ThemeSongs from "./ThemeSongs";
 import fightSong from "../assets/fightSong.mp3";
 import Types from "./Types";
 import PokemonCry from "./PokemonCry";
-import { useScroll } from "../hooks";
+import MovesList from "./MovesList";
 
 const EnemyPokemon = ({ enemyPokemon, hasEnemy }) => {
   const [enemyStatsOnTop, setEnemyStatsOnTop] = useState(true);
-  const [isScrollBottom, onScroll, scrollRef, scrollTop] = useScroll();
 
   // This checks if the moves property exist in pokemon object.
   const checkDoesMovesKeyExistInObject = () =>
     Object.prototype.hasOwnProperty.call(enemyPokemon, "moves");
-  // This checks if the moves list length is less than or equal to 7.
-  const checkIsMovesListLengthSevenOrLess = () =>
-    enemyPokemon?.moves.length <= 7;
-  // This checks if the stats list has been selected.
-  const checkIsStatsListSelected = () => enemyStatsOnTop;
-  // This checks if the scrollbar is at the top.
-  const checkIsScrollbarAtTop = () => scrollTop < 1;
-  // This checks if the scrollbar is at the bottom.
-  const checkIsScrollbarAtBottom = () => isScrollBottom;
-
-  /**
-   * To render the top-arrow, this function checks to see if the pokemon moves exist AND the scrollbar is not at the top AND the stats list has not been selected.
-   * @returns {boolean} A boolean.
-   */
-  const renderMovesListTopArrow = () =>
-    // True if the moves property exist in pokemon object.
-    checkDoesMovesKeyExistInObject() &&
-    // True if the scrollbar is not at the top.
-    !checkIsScrollbarAtTop() &&
-    // True if the stats list has not been selected.
-    !checkIsStatsListSelected();
-
-  /**
-   * To render the bottom-arrow, this function checks to see if the pokemon moves exist AND its moves length is not seven or less AND the scrollbar is not at the bottom AND the stats list has not been selected.
-   * @returns {boolean} A boolean.
-   */
-  const renderMovesListBottomArrow = () =>
-    // True if the moves property exist in pokemon object.
-    checkDoesMovesKeyExistInObject() &&
-    // True if the moves length is greater than seven.
-    !checkIsMovesListLengthSevenOrLess() &&
-    // True if the scrollbar is not at the bottom.
-    !checkIsScrollbarAtBottom() &&
-    // True if the stats list has not been selected.
-    !checkIsStatsListSelected();
 
   return (
     <>
@@ -83,7 +47,7 @@ const EnemyPokemon = ({ enemyPokemon, hasEnemy }) => {
 
             <div
               onClick={() => setEnemyStatsOnTop(false)}
-              className={`enemy-pokemon__moves-title ${
+              className={`enemy-moves-title ${
                 enemyStatsOnTop ? "" : "on-tip-top"
               }`}
             >
@@ -107,28 +71,12 @@ const EnemyPokemon = ({ enemyPokemon, hasEnemy }) => {
               </ol>
             </div>
 
-            <div
-              className={`enemy-pokemon__moves ${
-                enemyStatsOnTop ? "" : "on-top"
-              }`}
-              ref={scrollRef}
-              onScroll={onScroll}
-            >
-              <ol className="enemy-pokemon__moves-list">
-                {!enemyPokemon?.moves
-                  ? null
-                  : enemyPokemon?.moves.map((moveData, moveIndex) => (
-                      <li key={moveIndex}>{moveData.move.name}</li>
-                    ))}
-              </ol>
-            </div>
-
-            {renderMovesListTopArrow() && (
-              <span className="enemy-moves-list--up-arrow"></span>
-            )}
-
-            {renderMovesListBottomArrow() && (
-              <span className="enemy-moves-list--down-arrow"></span>
+            {checkDoesMovesKeyExistInObject() && (
+              <MovesList
+                pokemonMoves={enemyPokemon?.moves}
+                statsOnTop={enemyStatsOnTop}
+                isEnemyPokemon
+              />
             )}
 
             <div className="enemy-poke">Enemy Pokemon</div>

--- a/pokemon-app/src/components/MovesList.js
+++ b/pokemon-app/src/components/MovesList.js
@@ -1,0 +1,74 @@
+import React from "react";
+import { useScroll } from "../hooks";
+import "../styles/MovesList.css";
+
+const MovesList = ({ pokemonMoves, hasEnemy, statsOnTop, isEnemyPokemon }) => {
+  const [isScrollBottom, onScroll, scrollRef, scrollTop] = useScroll();
+
+  // This checks if the moves list length is less than or equal to 7.
+  const checkIsMovesListLengthSevenOrLess = () => pokemonMoves.length <= 7;
+  // This checks if the stats list has been selected.
+  const checkIsStatsListSelected = () => statsOnTop;
+  // This checks if the scrollbar is at the top.
+  const checkIsScrollbarAtTop = () => scrollTop < 1;
+  // This checks if the scrollbar is at the bottom.
+  const checkIsScrollbarAtBottom = () => isScrollBottom;
+
+  /**
+   * To render the top-arrow, this function checks to see if the scrollbar is not at the top AND the stats list has not been selected.
+   * @returns {boolean} A boolean.
+   */
+  const renderMovesListTopArrow = () =>
+    // True if the scrollbar is not at the top.
+    !checkIsScrollbarAtTop() &&
+    // True if the stats list has not been selected.
+    !checkIsStatsListSelected();
+
+  /**
+   * To render the bottom-arrow, this function checks to see if its moves length is not seven or less AND the scrollbar is not at the bottom AND the stats list has not been selected.
+   * @returns {boolean} A boolean.
+   */
+  const renderMovesListBottomArrow = () =>
+    // True if the moves length is greater than seven.
+    !checkIsMovesListLengthSevenOrLess() &&
+    // True if the scrollbar is not at the bottom.
+    !checkIsScrollbarAtBottom() &&
+    // True if the stats list has not been selected.
+    !checkIsStatsListSelected();
+
+  return (
+    <>
+      <div
+        className={`${isEnemyPokemon ? "enemy-" : ""}moves-box ${
+          hasEnemy ? "has-enemy" : ""
+        } ${statsOnTop ? "" : "on-top"}`}
+        ref={scrollRef}
+        onScroll={onScroll}
+      >
+        <ol id={`${isEnemyPokemon ? "enemy-" : ""}moves-list`}>
+          {pokemonMoves.map((moveData, moveIndex) => (
+            <li key={moveIndex}>{moveData.move.name}</li>
+          ))}
+        </ol>
+      </div>
+
+      {renderMovesListTopArrow() && (
+        <span
+          className={`${isEnemyPokemon ? "enemy-" : ""}moves-list--up-arrow ${
+            hasEnemy ? "has-enemy" : ""
+          }`}
+        ></span>
+      )}
+
+      {renderMovesListBottomArrow() && (
+        <span
+          className={`${isEnemyPokemon ? "enemy-" : ""}moves-list--down-arrow ${
+            hasEnemy ? "has-enemy" : ""
+          }`}
+        ></span>
+      )}
+    </>
+  );
+};
+
+export default MovesList;

--- a/pokemon-app/src/components/SinglePokemon.js
+++ b/pokemon-app/src/components/SinglePokemon.js
@@ -7,8 +7,8 @@ import ThemeSongs from "./ThemeSongs";
 import homeSong from "../assets/homeSong.mp3";
 import Types from "./Types";
 import PokemonCry from "./PokemonCry";
+import MovesList from "./MovesList";
 import { useState } from "react";
-import { useScroll } from "../hooks";
 
 const SinglePokemon = ({
   pokemon,
@@ -18,45 +18,10 @@ const SinglePokemon = ({
   isPokeballRendering,
 }) => {
   const [statsOnTop, setStatsOnTop] = useState(false);
-  const [isScrollBottom, onScroll, scrollRef, scrollTop] = useScroll();
 
   // This checks if the moves property exist in pokemon object.
   const checkDoesMovesKeyExistInObject = () =>
     Object.prototype.hasOwnProperty.call(pokemon, "moves");
-  // This checks if the moves list length is less than or equal to 7.
-  const checkIsMovesListLengthSevenOrLess = () => pokemon?.moves.length <= 7;
-  // This checks if the stats list has been selected.
-  const checkIsStatsListSelected = () => statsOnTop;
-  // This checks if the scrollbar is at the top.
-  const checkIsScrollbarAtTop = () => scrollTop < 1;
-  // This checks if the scrollbar is at the bottom.
-  const checkIsScrollbarAtBottom = () => isScrollBottom;
-
-  /**
-   * To render the top-arrow, this function checks to see if the pokemon moves exist AND the scrollbar is not at the top AND the stats list has not been selected.
-   * @returns {boolean} A boolean.
-   */
-  const renderMovesListTopArrow = () =>
-    // True if the moves property exist in pokemon object.
-    checkDoesMovesKeyExistInObject() &&
-    // True if the scrollbar is not at the top.
-    !checkIsScrollbarAtTop() &&
-    // True if the stats list has not been selected.
-    !checkIsStatsListSelected();
-
-  /**
-   * To render the bottom-arrow, this function checks to see if the pokemon moves exist AND its moves length is not seven or less AND the scrollbar is not at the bottom AND the stats list has not been selected.
-   * @returns {boolean} A boolean.
-   */
-  const renderMovesListBottomArrow = () =>
-    // True if the moves property exist in pokemon object.
-    checkDoesMovesKeyExistInObject() &&
-    // True if the moves length is greater than seven.
-    !checkIsMovesListLengthSevenOrLess() &&
-    // True if the scrollbar is not at the bottom.
-    !checkIsScrollbarAtBottom() &&
-    // True if the stats list has not been selected.
-    !checkIsStatsListSelected();
 
   return (
     <>
@@ -118,36 +83,12 @@ const SinglePokemon = ({
                 Your Pokemon
               </div>
 
-              <div
-                className={`moves-box ${hasEnemy ? "has-enemy" : ""} ${
-                  statsOnTop ? "" : "on-top"
-                }`}
-                ref={scrollRef}
-                onScroll={onScroll}
-              >
-                <ol id="moves-list">
-                  {!pokemon?.moves
-                    ? null
-                    : pokemon?.moves.map((moveData, moveIndex) => (
-                        <li key={moveIndex}>{moveData.move.name}</li>
-                      ))}
-                </ol>
-              </div>
-
-              {renderMovesListTopArrow() && (
-                <span
-                  className={`moves-list--up-arrow ${
-                    hasEnemy ? "has-enemy" : ""
-                  }`}
-                ></span>
-              )}
-
-              {renderMovesListBottomArrow() && (
-                <span
-                  className={`moves-list--down-arrow ${
-                    hasEnemy ? "has-enemy" : ""
-                  }`}
-                ></span>
+              {checkDoesMovesKeyExistInObject() && (
+                <MovesList
+                  pokemonMoves={pokemon?.moves}
+                  hasEnemy={hasEnemy}
+                  statsOnTop={statsOnTop}
+                />
               )}
             </div>
             <div className={`pokemon-types ${hasEnemy ? "has-enemy" : ""}`}>

--- a/pokemon-app/src/styles/EnemyPokemon.css
+++ b/pokemon-app/src/styles/EnemyPokemon.css
@@ -49,7 +49,6 @@
   width: 100%;
   height: 95%;
 }
-.enemy-pokemon__moves-title,
 .enemy-pokemon__stats-title {
   position: absolute;
   font-size: 1.8em;
@@ -67,8 +66,7 @@
   z-index: 0;
 }
 
-.enemy-pokemon__stats,
-.enemy-pokemon__moves {
+.enemy-pokemon__stats {
   z-index: 1;
   box-sizing: border-box;
   font-size: 1em;
@@ -88,17 +86,14 @@
   background-color: rgb(160, 212, 212);
   z-index: 0;
 }
-.enemy-pokemon__stats::-webkit-scrollbar,
-.enemy-pokemon__moves::-webkit-scrollbar {
+.enemy-pokemon__stats::-webkit-scrollbar {
   width: 8.6px;
   height: 7.6px;
 }
-.enemy-pokemon__stats::-webkit-scrollbar-track,
-.enemy-pokemon__moves::-webkit-scrollbar-track {
+.enemy-pokemon__stats::-webkit-scrollbar-track {
   background: transparent;
 }
-.enemy-pokemon__stats::-webkit-scrollbar-thumb,
-.enemy-pokemon__moves::-webkit-scrollbar-thumb {
+.enemy-pokemon__stats::-webkit-scrollbar-thumb {
   background-color: rgba(0, 0, 0, 0.18);
   border-radius: 50px;
   border: 1px solid rgba(0, 0, 0, 0.5);
@@ -110,13 +105,11 @@
   z-index: 3;
 }
 
-.enemy-pokemon__stats-list,
-.enemy-pokemon__moves-list {
+.enemy-pokemon__stats-list {
   margin: 5px;
 }
 
-.enemy-pokemon__stats-list > li,
-.enemy-pokemon__moves-list > li {
+.enemy-pokemon__stats-list > li {
   font-size: 1em;
   margin: 10px;
 }
@@ -129,7 +122,6 @@
   transform: scale(1.4);
 }
 
-.enemy-pokemon__moves-title:hover,
 .enemy-pokemon__stats-title:hover {
   cursor: pointer;
 }
@@ -165,61 +157,4 @@
 
 .user-poke-none {
   display: none;
-}
-
-.enemy-moves-list--up-arrow {
-  position: absolute;
-  top: 11%;
-  left: 45.5%;
-  width: 0;
-  height: 0;
-  border-left: 7px solid transparent;
-  border-right: 7px solid transparent;
-  border-bottom: 7px solid #b11501;
-  z-index: 3;
-  animation-duration: 0.8s;
-  animation-iteration-count: infinite;
-  animation-timing-function: ease-in-out;
-  animation-name: uparrowmovesenemy;
-}
-
-.enemy-moves-list--down-arrow {
-  position: absolute;
-  top: 38%;
-  left: 45.5%;
-  width: 0;
-  height: 0;
-  border-left: 7px solid transparent;
-  border-right: 7px solid transparent;
-  border-top: 7px solid #b11501;
-  z-index: 3;
-  animation-duration: 0.8s;
-  animation-iteration-count: infinite;
-  animation-timing-function: ease-in-out;
-  animation-name: downarrowmovesenemy;
-}
-
-/**************/
-/* ANIMATIONS */
-/**************/
-
-/* ENEMY-MOVES-LIST ARROWS MOVES */
-@keyframes uparrowmovesenemy {
-  from {
-    top: 11%;
-  }
-
-  to {
-    top: 10.6%;
-  }
-}
-
-@keyframes downarrowmovesenemy {
-  from {
-    top: 38%;
-  }
-
-  to {
-    top: 38.4%;
-  }
 }

--- a/pokemon-app/src/styles/MovesList.css
+++ b/pokemon-app/src/styles/MovesList.css
@@ -1,0 +1,246 @@
+.moves-title {
+  position: absolute;
+  font-size: 1.8em;
+  border: solid black 6px;
+  border-radius: 15px;
+  padding: 0.1em;
+  background-color: #fdf0c4;
+  right: 27%;
+  top: 4.5%;
+  z-index: 2;
+}
+.enemy-moves-title {
+  position: absolute;
+  font-size: 1.8em;
+  border: solid black 6px;
+  border-radius: 15px;
+  padding: 0.2em;
+  background-color: #fdf0c4;
+  left: 3%;
+  top: 3%;
+  z-index: 2;
+}
+.moves-title.has-enemy {
+  top: 55%;
+}
+.moves-title:hover,
+.enemy-moves-title:hover {
+  cursor: pointer;
+}
+.moves-box {
+  z-index: 1;
+  box-sizing: border-box;
+  font-size: 1em;
+  height: 32%;
+  width: 47%;
+  top: 10%;
+  right: 3%;
+  border: 6px solid black;
+  border-radius: 15px;
+  background-color: #fdf0c4;
+  position: absolute;
+  overflow-y: auto;
+  padding-top: 2%;
+  box-shadow: 0.3em 0.3em rgba(0, 0, 0, 0.3);
+}
+.enemy-moves-box {
+  z-index: 1;
+  box-sizing: border-box;
+  font-size: 1em;
+  height: 32%;
+  width: 47%;
+  top: 9%;
+  left: 3%;
+  border: 6px solid black;
+  border-radius: 15px;
+  background-color: #fdf0c4;
+  position: absolute;
+  overflow-y: auto;
+  padding-top: 2%;
+  box-shadow: 0.3em 0.3em rgba(0, 0, 0, 0.3);
+}
+.moves-box.has-enemy {
+  top: 61%;
+}
+.moves-box::-webkit-scrollbar,
+.enemy-moves-box::-webkit-scrollbar {
+  width: 8.6px;
+  height: 7.6px;
+}
+.moves-box::-webkit-scrollbar-track,
+.enemy-moves-box::-webkit-scrollbar-track {
+  background: transparent;
+}
+.moves-box::-webkit-scrollbar-thumb,
+.enemy-moves-box::-webkit-scrollbar-thumb {
+  background-color: rgba(0, 0, 0, 0.18);
+  border-radius: 50px;
+  border: 1px solid rgba(0, 0, 0, 0.5);
+}
+
+#moves-list,
+#enemy-moves-list {
+  margin: 5px;
+}
+
+#moves-list > li,
+#enemy-moves-list > li {
+  font-size: 1em;
+  margin: 10px;
+}
+
+.moves-list--up-arrow {
+  position: absolute;
+  top: 12%;
+  right: 5.5%;
+  width: 0;
+  height: 0;
+  border-left: 7px solid transparent;
+  border-right: 7px solid transparent;
+  border-bottom: 7px solid #b11501;
+  z-index: 3;
+  animation-duration: 0.8s;
+  animation-iteration-count: infinite;
+  animation-timing-function: ease-in-out;
+  animation-name: uparrowmoves;
+}
+.moves-list--up-arrow.has-enemy {
+  position: absolute;
+  top: 63%;
+  right: 5.5%;
+  width: 0;
+  height: 0;
+  border-left: 7px solid transparent;
+  border-right: 7px solid transparent;
+  border-bottom: 7px solid #b11501;
+  z-index: 3;
+  animation-duration: 0.8s;
+  animation-iteration-count: infinite;
+  animation-timing-function: ease-in-out;
+  animation-name: uparrowmoves2;
+}
+.enemy-moves-list--up-arrow {
+  position: absolute;
+  top: 11%;
+  left: 45.5%;
+  width: 0;
+  height: 0;
+  border-left: 7px solid transparent;
+  border-right: 7px solid transparent;
+  border-bottom: 7px solid #b11501;
+  z-index: 3;
+  animation-duration: 0.8s;
+  animation-iteration-count: infinite;
+  animation-timing-function: ease-in-out;
+  animation-name: uparrowmovesenemy;
+}
+
+.moves-list--down-arrow {
+  position: absolute;
+  top: 39%;
+  right: 5.5%;
+  width: 0;
+  height: 0;
+  border-left: 7px solid transparent;
+  border-right: 7px solid transparent;
+  border-top: 7px solid #b11501;
+  z-index: 3;
+  animation-duration: 0.8s;
+  animation-iteration-count: infinite;
+  animation-timing-function: ease-in-out;
+  animation-name: downarrowmoves;
+}
+.moves-list--down-arrow.has-enemy {
+  position: absolute;
+  top: 90%;
+  right: 5.5%;
+  width: 0;
+  height: 0;
+  border-left: 7px solid transparent;
+  border-right: 7px solid transparent;
+  border-top: 7px solid #b11501;
+  z-index: 3;
+  animation-duration: 0.8s;
+  animation-iteration-count: infinite;
+  animation-timing-function: ease-in-out;
+  animation-name: downarrowmoves2;
+}
+.enemy-moves-list--down-arrow {
+  position: absolute;
+  top: 38%;
+  left: 45.5%;
+  width: 0;
+  height: 0;
+  border-left: 7px solid transparent;
+  border-right: 7px solid transparent;
+  border-top: 7px solid #b11501;
+  z-index: 3;
+  animation-duration: 0.8s;
+  animation-iteration-count: infinite;
+  animation-timing-function: ease-in-out;
+  animation-name: downarrowmovesenemy;
+}
+
+/**************/
+/* ANIMATIONS */
+/**************/
+
+/* NON-ENEMY MOVES-LIST ARROWS MOVES */
+@keyframes uparrowmoves {
+  from {
+    top: 12%;
+  }
+
+  to {
+    top: 11.6%;
+  }
+}
+@keyframes uparrowmoves2 {
+  from {
+    top: 63%;
+  }
+
+  to {
+    top: 62.6%;
+  }
+}
+
+@keyframes downarrowmoves {
+  from {
+    top: 39%;
+  }
+
+  to {
+    top: 39.4%;
+  }
+}
+@keyframes downarrowmoves2 {
+  from {
+    top: 90%;
+  }
+
+  to {
+    top: 90.4%;
+  }
+}
+
+/* ENEMY-MOVES-LIST ARROWS MOVES */
+@keyframes uparrowmovesenemy {
+  from {
+    top: 11%;
+  }
+
+  to {
+    top: 10.6%;
+  }
+}
+
+@keyframes downarrowmovesenemy {
+  from {
+    top: 38%;
+  }
+
+  to {
+    top: 38.4%;
+  }
+}

--- a/pokemon-app/src/styles/One-pokemon-page.css
+++ b/pokemon-app/src/styles/One-pokemon-page.css
@@ -52,7 +52,6 @@
 .poke-pad.has-enemy {
   top: 76%;
 }
-.moves-title,
 .stats-title {
   position: absolute;
   font-size: 1.8em;
@@ -69,16 +68,13 @@
   background-color: rgb(160, 212, 212);
   z-index: 0;
 }
-.moves-title.has-enemy,
 .stats-title.has-enemy {
   top: 55%;
 }
-.moves-title:hover,
 .stats-title:hover {
   cursor: pointer;
 }
-.stats-box,
-.moves-box {
+.stats-box {
   z-index: 1;
   box-sizing: border-box;
   font-size: 1em;
@@ -104,97 +100,29 @@
 .on-top {
   z-index: 3;
 }
-.stats-box.has-enemy,
-.moves-box.has-enemy {
+.stats-box.has-enemy {
   top: 61%;
 }
-.stats-box::-webkit-scrollbar,
-.moves-box::-webkit-scrollbar {
+.stats-box::-webkit-scrollbar {
   width: 8.6px;
   height: 7.6px;
 }
-.stats-box::-webkit-scrollbar-track,
-.moves-box::-webkit-scrollbar-track {
+.stats-box::-webkit-scrollbar-track {
   background: transparent;
 }
-.stats-box::-webkit-scrollbar-thumb,
-.moves-box::-webkit-scrollbar-thumb {
+.stats-box::-webkit-scrollbar-thumb {
   background-color: rgba(0, 0, 0, 0.18);
   border-radius: 50px;
   border: 1px solid rgba(0, 0, 0, 0.5);
 }
 
-#stats-list,
-#moves-list {
+#stats-list {
   margin: 5px;
 }
 
-#stats-list > li,
-#moves-list > li {
+#stats-list > li {
   font-size: 1em;
   margin: 10px;
-}
-
-.moves-list--up-arrow {
-  position: absolute;
-  top: 12%;
-  right: 5.5%;
-  width: 0;
-  height: 0;
-  border-left: 7px solid transparent;
-  border-right: 7px solid transparent;
-  border-bottom: 7px solid #b11501;
-  z-index: 3;
-  animation-duration: 0.8s;
-  animation-iteration-count: infinite;
-  animation-timing-function: ease-in-out;
-  animation-name: uparrowmoves;
-}
-.moves-list--up-arrow.has-enemy {
-  position: absolute;
-  top: 63%;
-  right: 5.5%;
-  width: 0;
-  height: 0;
-  border-left: 7px solid transparent;
-  border-right: 7px solid transparent;
-  border-bottom: 7px solid #b11501;
-  z-index: 3;
-  animation-duration: 0.8s;
-  animation-iteration-count: infinite;
-  animation-timing-function: ease-in-out;
-  animation-name: uparrowmoves2;
-}
-
-.moves-list--down-arrow {
-  position: absolute;
-  top: 39%;
-  right: 5.5%;
-  width: 0;
-  height: 0;
-  border-left: 7px solid transparent;
-  border-right: 7px solid transparent;
-  border-top: 7px solid #b11501;
-  z-index: 3;
-  animation-duration: 0.8s;
-  animation-iteration-count: infinite;
-  animation-timing-function: ease-in-out;
-  animation-name: downarrowmoves;
-}
-.moves-list--down-arrow.has-enemy {
-  position: absolute;
-  top: 90%;
-  right: 5.5%;
-  width: 0;
-  height: 0;
-  border-left: 7px solid transparent;
-  border-right: 7px solid transparent;
-  border-top: 7px solid #b11501;
-  z-index: 3;
-  animation-duration: 0.8s;
-  animation-iteration-count: infinite;
-  animation-timing-function: ease-in-out;
-  animation-name: downarrowmoves2;
 }
 
 .pokemon-types {
@@ -207,47 +135,4 @@
 .pokemon-types.has-enemy {
   top: 90%;
   left: 18%;
-}
-
-/**************/
-/* ANIMATIONS */
-/**************/
-
-/* MOVES-LIST ARROWS MOVES */
-@keyframes uparrowmoves {
-  from {
-    top: 12%;
-  }
-
-  to {
-    top: 11.6%;
-  }
-}
-@keyframes uparrowmoves2 {
-  from {
-    top: 63%;
-  }
-
-  to {
-    top: 62.6%;
-  }
-}
-
-@keyframes downarrowmoves {
-  from {
-    top: 39%;
-  }
-
-  to {
-    top: 39.4%;
-  }
-}
-@keyframes downarrowmoves2 {
-  from {
-    top: 90%;
-  }
-
-  to {
-    top: 90.4%;
-  }
 }


### PR DESCRIPTION
## Changes
1. Created a MovesList component.
2. Styled the MovesList component with MovesList.css.
3. Refactored anything with moves-list styles from One-Pokemon-page.css to MovesList.css.
4. Refactored anything with enemy-pokemon__moves-list styles from EnemyPokemon.css to MovesList.css.
5. Changed the classnames from enemy-pokemon__moves-list to enemy-moves-list in MovesList.css.
6. Refactored the useScroll custom hook from SinglePokemon.js to MovesList.js.
7. Refactored some of the render conditional functions from SinglePokemon.js to MovesList.js.
8. Rendered the MovesList component in SinglePokemon.js.
9. Refactored the useScroll custom hook from EnemyPokemon.js to MovesList.js.
10. Refactored some of the render conditional functions from EnemyPokemon.js to MovesList.js.
11. Rendered the MovesList component in EnemyPokemon.js.
12. Changed enemy-pokemon__moves-title to enemy-moves-title in EnemyPokemon.js

## Purpose
The problem was that the moves-list was duplicated in both SinglePokemon and EnemyPokemon components, but with different classNames whether or not it is an enemy type. There should be a new component which houses the moves-list along with related CSS.

## Approach
A solution would be to create a component called MovesList, and render it in both SinglePokemon.js and EnemyPokemon.js. Any functionalities related to the MovesList component (such as the useScroll custom hook and some of the render conditional functions) would be housed inside. Any CSS properties related to MovesList is taken out of One-Pokemon-page.css and EnemyPokemon.css to be placed inside MovesList.css. This helps to keep code clean and avoid redundancy.

## Screenshots
![hello-reactoads](https://user-images.githubusercontent.com/29642735/127715286-d3598f89-ef76-42de-8ef4-9258d5c5c06a.gif)


Closes #70 