### PR TITLE
fix(evolutions-scrollbar): increase the width of the border, and decr…

### DIFF
--- a/pokemon-app/src/styles/Poke-evolutions.css
+++ b/pokemon-app/src/styles/Poke-evolutions.css
@@ -26,8 +26,8 @@
   overflow-x: auto;
   padding: 0.8em 0 0.2em 0.5em;
   background-color: grey;
-  border: 5px solid black;
-  border-radius: 25px;
+  border: 6px solid black;
+  border-radius: 15px;
 }
 .pokemon-evolutions__card-wrapper.eevee {
   justify-content: space-between;


### PR DESCRIPTION
## Changes
1. Increased the width of the `border` and decreased the `border-radius` in `Poke-evolutions.css` so that the scrollbar on the x-direction does not stick out.

## Purpose
The scrollbar on the x-direction is sticking out when there is a pokemon with an evolution chain of more than 3. There needs to be a way to hide the sticking out part.

## Approach
When there is a pokemon with more than 3 evolutions, the ends of the scrollbar on the x-direction sticks outside of the container. To fix this is to increase the width `border` CSS property, and decrease the `border` CSS property. This helps to hide the ends of the scrollbar from sticking out.

Closes #90 