### PR TITLE
fix(type-scrollbar): increase the border properties for type-title, t…

### DIFF
--- a/pokemon-app/src/styles/TypeCheck.css
+++ b/pokemon-app/src/styles/TypeCheck.css
@@ -1,53 +1,58 @@
-.type-check{
-    position: absolute;
-    top: 75%;
-    height: 15%;
-    width: 98%;
-    font-size: 0.8em;
+.type-check {
+  position: absolute;
+  top: 75%;
+  height: 15%;
+  width: 98%;
+  font-size: 0.8em;
 }
-.type-title{
-    position: absolute;
-    background-color: #5D5D5D;
-    color: white;
-    height: 40%;
-    width: 98%;
-    left: 1%;
-    border: solid black 0.2em;
-    display: flex;
-    justify-content: space-evenly;
-    align-items: center;
-    border-radius: 15px;
+.type-title {
+  position: absolute;
+  background-color: #5d5d5d;
+  color: white;
+  height: 40%;
+  width: 98%;
+  left: 1%;
+  border: solid black 0.32em;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: center;
+  border-radius: 15px;
 }
-.type-details-0, .type-details-1{
-    position: absolute;
-    background-color: white;
-    height: 50%;
-    top: 41%;
-    left: 1%;
-    width: 98%;
-    border: solid black 0.22em;
-    border-radius: 15px;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    overflow-y: auto;
+.type-details-0,
+.type-details-1 {
+  position: absolute;
+  background-color: white;
+  height: 50%;
+  top: 41%;
+  left: 1%;
+  width: 98%;
+  border: solid black 0.32em;
+  border-radius: 15px;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  overflow-y: auto;
 }
-.type-details-0 > div, .type-details-1 > div{
-    width: 20%;
-    text-align: center;
+.type-details-0 > div,
+.type-details-1 > div {
+  width: 20%;
+  text-align: center;
 }
-.type-details-1{
-    top: 92%;
+.type-details-1 {
+  top: 94%;
 }
-.type-details-0::-webkit-scrollbar, .type-details-1::-webkit-scrollbar{
-    width: 8.6px;
-    height: 7.6px;
+.type-details-0::-webkit-scrollbar,
+.type-details-1::-webkit-scrollbar {
+  width: 8.6px;
+  height: 7.6px;
 }
-.type-details-0::-webkit-scrollbar-track, .type-details-1::-webkit-scrollbar-track{
-    background: transparent;
+.type-details-0::-webkit-scrollbar-track,
+.type-details-1::-webkit-scrollbar-track {
+  background: transparent;
 }
-.type-details-0::-webkit-scrollbar-thumb, .type-details-1::-webkit-scrollbar-thumb{
-    background-color: rgba(0, 0, 0, 0.18);
-    border-radius: 50px;
-    border: 1px solid rgba(0, 0, 0, 0.5);
+.type-details-0::-webkit-scrollbar-thumb,
+.type-details-1::-webkit-scrollbar-thumb {
+  background-color: rgba(0, 0, 0, 0.18);
+  border-radius: 50px;
+  border: 1px solid rgba(0, 0, 0, 0.5);
 }


### PR DESCRIPTION
## Changes
1. Increased the `border` property for classes `type-title` and `type-details`, and increased the `top` property for class `type-details-1` so that the scrollbar on the y-direction does not stick out.

## Purpose
The top end scrollbar on the y-direction is sticking out when a pokemon has extra values in "strong against", "weak against", "vulnerable to", and/or "resistant to". There needs to be a way to hide the top end scrollbar from sticking out.

## Approach
When a pokemon has extra values in "strong against", "weak against", "vulnerable to", and/or "resistant to", the ends of the scrollbar on the y-direction sticks outside of the container. To fix this is to increase the width of the border CSS property, and increase the top CSS property.

Closes #97 