### PR TITLE
bug(pokemon-types):set the Pokémon type to a specific spot on the page when on mobile

### DIFF
--- a/pokemon-app/src/styles/EnemyPokemon-mobile.css
+++ b/pokemon-app/src/styles/EnemyPokemon-mobile.css
@@ -59,9 +59,9 @@
     padding-left: 16%;
   }
   .enemy-pokemon-types {
-    position: absolute;
-    top: 34%;
-    right: 17%;
+    position: fixed;
+    top: 33%;
+    right: 31%;
   }
   #enemy-moves-list {
     padding-left: 16%;

--- a/pokemon-app/src/styles/One-pokemon-page-mobile.css
+++ b/pokemon-app/src/styles/One-pokemon-page-mobile.css
@@ -2,11 +2,6 @@
   .type-name {
     font-size: 1.4vw;
   }
-  div.pokemon-types.has-enemy > .type-name {
-    position: absolute;
-    left: 50%;
-    top: 1vh;
-  }
   .poke-name {
     position: fixed;
     top: 11%;
@@ -23,6 +18,16 @@
     width: 18%;
     height: 13%;
     margin-left: 0;
+  }
+  .pokemon-types {
+    position: fixed;
+    top: 33%;
+    left: 22%;
+  }
+  .pokemon-types.has-enemy {
+    position: fixed;
+    top: 72%;
+    left: 22%;
   }
   .Poke-display-container.has-enemy .poke-image {
     top: 60%;


### PR DESCRIPTION
## Changes
1. Change the placements of the Pokémon types

## Purpose
So the Pokémon types look better on mobile

## Approach
Setting the Pokémon types to a fixed position when the app is on mobile

Closes #118 